### PR TITLE
Feature/polishing the auth flows

### DIFF
--- a/time_tracker_flutter_course/lib/app/sign_in/email_sign_in_form.dart
+++ b/time_tracker_flutter_course/lib/app/sign_in/email_sign_in_form.dart
@@ -30,6 +30,17 @@ class _EmailSignInFormState extends State<EmailSignInForm> {
   bool _submitted = false;
   bool _isLoading = false;
 
+  // El método dispose() es definido en el State de la clase.
+  // Es invocado cuando un 'widget' es removido del 'widget tree'
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _emailFocusNode.dispose();
+    _passwordFocusNode.dispose();
+    super.dispose();
+  }
+
   void _submit() async {
     setState(() {
       _submitted = true;

--- a/time_tracker_flutter_course/lib/app/sign_in/email_sign_in_form.dart
+++ b/time_tracker_flutter_course/lib/app/sign_in/email_sign_in_form.dart
@@ -1,5 +1,7 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../../common_widgets/show_exception_alert_dialog.dart';
 import '../services/auth.dart';
 import '/app/sign_in/validators.dart';
 import '/common_widgets/form_submit_button.dart';
@@ -42,12 +44,13 @@ class _EmailSignInFormState extends State<EmailSignInForm> {
         await auth.createUserWithEmailAndPassword(_email, _password);
       }
       Navigator.of(context).pop();
-    } catch (e) {
+    } on FirebaseAuthException catch (e) {
       // Personalizar los widgets Dialog para cada plataforma
-      showAlertDialog(context,
-          title: 'Sign in failed',
-          content: e.toString(),
-          defaultActionText: 'Ok');
+      showExceptionAlertDialog(
+        context,
+        title: 'Sign in failed',
+        exception: e,
+      );
     } finally {
       // finally se ejecuta en todos los casos: si se ejecuta o falla la instrucción
       setState(() {

--- a/time_tracker_flutter_course/lib/app/sign_in/sign_in_button.dart
+++ b/time_tracker_flutter_course/lib/app/sign_in/sign_in_button.dart
@@ -6,7 +6,7 @@ class SignInButton extends CustomRaisedButton {
     required String text,
     required Color color,
     required Color textColor,
-    required VoidCallback onPressed,
+    VoidCallback? onPressed,
   }) : super(
           child: Text(
             text,

--- a/time_tracker_flutter_course/lib/app/sign_in/sign_in_page.dart
+++ b/time_tracker_flutter_course/lib/app/sign_in/sign_in_page.dart
@@ -1,11 +1,25 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../../common_widgets/show_exception_alert_dialog.dart';
 import '../services/auth.dart';
 import 'sign_in_button.dart';
 import 'email_sign_in_page.dart';
 import 'social_sign_in_button.dart';
 
 class SignInPage extends StatelessWidget {
+  void _showSignInError(BuildContext context, Exception exception) {
+    if (exception is FirebaseException &&
+        exception.code == 'ERROR_ABORTED_BY_USER') {
+      return;
+    }
+    showExceptionAlertDialog(
+      context,
+      title: 'Sign in failed',
+      exception: exception,
+    );
+  }
+
   // Inicio de sesión de forma anónima
   Future<void> _signInAnonymously(BuildContext context) async {
     /*
@@ -17,8 +31,8 @@ class SignInPage extends StatelessWidget {
     try {
       final auth = Provider.of<AuthBase>(context, listen: false);
       await auth.signInAnonymously();
-    } catch (e) {
-      print(e.toString());
+    } on Exception catch (e) {
+      _showSignInError(context, e);
     }
   }
 
@@ -27,8 +41,8 @@ class SignInPage extends StatelessWidget {
     try {
       final auth = Provider.of<AuthBase>(context, listen: false);
       await auth.signInWithGoogle();
-    } catch (e) {
-      print(e.toString());
+    } on Exception catch (e) {
+      _showSignInError(context, e);
     }
   }
 
@@ -37,8 +51,8 @@ class SignInPage extends StatelessWidget {
     try {
       final auth = Provider.of<AuthBase>(context, listen: false);
       await auth.signInWithFacebook();
-    } catch (e) {
-      print(e.toString());
+    } on Exception catch (e) {
+      _showSignInError(context, e);
     }
   }
 

--- a/time_tracker_flutter_course/lib/app/sign_in/sign_in_page.dart
+++ b/time_tracker_flutter_course/lib/app/sign_in/sign_in_page.dart
@@ -7,7 +7,14 @@ import 'sign_in_button.dart';
 import 'email_sign_in_page.dart';
 import 'social_sign_in_button.dart';
 
-class SignInPage extends StatelessWidget {
+class SignInPage extends StatefulWidget {
+  @override
+  State<SignInPage> createState() => _SignInPageState();
+}
+
+class _SignInPageState extends State<SignInPage> {
+  bool _isLoading = false;
+
   void _showSignInError(BuildContext context, Exception exception) {
     if (exception is FirebaseException &&
         exception.code == 'ERROR_ABORTED_BY_USER') {
@@ -29,30 +36,39 @@ class SignInPage extends StatelessWidget {
     */
     // Retorna un Future<UserCredencial>
     try {
+      setState(() => _isLoading = true);
       final auth = Provider.of<AuthBase>(context, listen: false);
       await auth.signInAnonymously();
     } on Exception catch (e) {
       _showSignInError(context, e);
+    } finally {
+      setState(() => _isLoading = false);
     }
   }
 
   // Inicio de sesión con Google
   Future<void> _signInWithGoogle(BuildContext context) async {
     try {
+      setState(() => _isLoading = true);
       final auth = Provider.of<AuthBase>(context, listen: false);
       await auth.signInWithGoogle();
     } on Exception catch (e) {
       _showSignInError(context, e);
+    } finally {
+      setState(() => _isLoading = false);
     }
   }
 
   // Inicio de sesión con Facebook
   Future<void> _signInWithFacebook(BuildContext context) async {
     try {
+      setState(() => _isLoading = true);
       final auth = Provider.of<AuthBase>(context, listen: false);
       await auth.signInWithFacebook();
     } on Exception catch (e) {
       _showSignInError(context, e);
+    } finally {
+      setState(() => _isLoading = false);
     }
   }
 
@@ -82,8 +98,6 @@ class SignInPage extends StatelessWidget {
   }
 
 // Se retorna un Widget, ya que Container hereda de Widget, así que no hay inconveniente.
-// Para hacer MÉTODOS PRIVADOS se debe anteponer "_" al nombre del método, los
-// cuales solo son accesibles dentro de la clase que lo contiene
   Widget _buildContent(BuildContext context) {
     return Container(
       padding: EdgeInsets.all(16.0),
@@ -94,22 +108,17 @@ class SignInPage extends StatelessWidget {
         // Para ocupar todo el ancho del container.
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          Text(
-            'Sign in',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: 32.0,
-              fontWeight: FontWeight.bold,
-            ),
+          SizedBox(
+            height: 50.0,
+            child: _buildHeader(),
           ),
-          SizedBox(height: 48.0),
           // Inicio de sesión con Google
           SocialSignInButton(
             assetName: 'images/google-logo.png',
             text: 'Sign in with Google',
             textColor: Colors.black87,
             color: Colors.white,
-            onPressed: () => _signInWithGoogle(context),
+            onPressed: _isLoading ? null : () => _signInWithGoogle(context),
           ),
           SizedBox(height: 8.0),
           // Inicio de sesión con Facebook
@@ -118,7 +127,7 @@ class SignInPage extends StatelessWidget {
             text: 'Sign in with Facebook',
             textColor: Colors.white,
             color: Color(0xFF334D92),
-            onPressed: () => _signInWithFacebook(context),
+            onPressed: _isLoading ? null : () => _signInWithFacebook(context),
           ),
           SizedBox(height: 8.0),
           // Inicio de sesión con Email
@@ -126,7 +135,8 @@ class SignInPage extends StatelessWidget {
             text: 'Sign in with email',
             textColor: Colors.white,
             color: (Colors.teal[700])!,
-            onPressed: () => _signInWithEmail(context),
+            onPressed: () =>
+                _isLoading ? null : () => _signInWithEmail(context),
           ),
           SizedBox(height: 8.0),
           Text(
@@ -146,9 +156,25 @@ class SignInPage extends StatelessWidget {
             textColor: Colors.black,
             color: (Colors.lime[300])!,
             // 'onPressed' es un callback, y no es necesario agregar (), pues no toma argumentos
-            onPressed: () => _signInAnonymously(context),
+            onPressed: _isLoading ? null : () => _signInAnonymously(context),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    if (_isLoading) {
+      return Center(
+        child: CircularProgressIndicator(),
+      );
+    }
+    return Text(
+      'Sign in',
+      textAlign: TextAlign.center,
+      style: TextStyle(
+        fontSize: 32.0,
+        fontWeight: FontWeight.bold,
       ),
     );
   }

--- a/time_tracker_flutter_course/lib/app/sign_in/sign_in_page.dart
+++ b/time_tracker_flutter_course/lib/app/sign_in/sign_in_page.dart
@@ -74,6 +74,7 @@ class _SignInPageState extends State<SignInPage> {
 
   // Inicio de sesión con Email
   void _signInWithEmail(BuildContext context) {
+    print('Click here...');
     // Para navegar entre Widgets hacemos uso del widget Navigator, el cual funciona
     // como una pila, con los métodos push y pop.
     Navigator.of(context).push(
@@ -112,6 +113,7 @@ class _SignInPageState extends State<SignInPage> {
             height: 50.0,
             child: _buildHeader(),
           ),
+          SizedBox(height: 48.0),
           // Inicio de sesión con Google
           SocialSignInButton(
             assetName: 'images/google-logo.png',
@@ -135,8 +137,7 @@ class _SignInPageState extends State<SignInPage> {
             text: 'Sign in with email',
             textColor: Colors.white,
             color: (Colors.teal[700])!,
-            onPressed: () =>
-                _isLoading ? null : () => _signInWithEmail(context),
+            onPressed: _isLoading ? null : () => _signInWithEmail(context),
           ),
           SizedBox(height: 8.0),
           Text(

--- a/time_tracker_flutter_course/lib/app/sign_in/social_sign_in_button.dart
+++ b/time_tracker_flutter_course/lib/app/sign_in/social_sign_in_button.dart
@@ -9,7 +9,7 @@ class SocialSignInButton extends CustomRaisedButton {
     required String text,
     required Color color,
     required textColor,
-    required VoidCallback onPressed,
+    VoidCallback? onPressed,
   }) : super(
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/time_tracker_flutter_course/lib/common_widgets/custom_raised_button.dart
+++ b/time_tracker_flutter_course/lib/common_widgets/custom_raised_button.dart
@@ -31,6 +31,7 @@ class CustomRaisedButton extends StatelessWidget {
         child: child,
         style: ElevatedButton.styleFrom(
           primary: color,
+          onSurface: color,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(borderRadius),
           ),

--- a/time_tracker_flutter_course/lib/common_widgets/show_exception_alert_dialog.dart
+++ b/time_tracker_flutter_course/lib/common_widgets/show_exception_alert_dialog.dart
@@ -1,0 +1,22 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:time_tracker_flutter_course/common_widgets/show_alert_dialog.dart';
+
+Future<void> showExceptionAlertDialog(
+  BuildContext context, {
+  required String title,
+  required Exception exception,
+}) =>
+    showAlertDialog(
+      context,
+      title: title,
+      content: _message(exception),
+      defaultActionText: 'Ok',
+    );
+
+String _message(Exception exception) {
+  if (exception is FirebaseAuthException) {
+    return (exception.message)!;
+  }
+  return exception.toString();
+}


### PR DESCRIPTION
## what

- Agregar widget showExceptionAlertDialog.
- Modificar archivos de los widgets SignInPage, EmailSignInForm y algunos botones.
- Agregar método dispose() al widget EmailSignInForm

## why

- El nuevo widget showExceptionAlertDialog permite mostrar un mensaje al usuario, si es que existe un error al iniciar sesión.
- Es necesario modificar el código de algunos archivos para agregar la nueva funcionalidad.
- El método dispose() es útil para remover un widget del 'widget tree'

## screenshots

![1650300308477](https://user-images.githubusercontent.com/43360869/164103915-5f0c5be1-f726-42fc-ba0a-b06e978226c2.jpg)

### HomePage (AlertDialog al intentar cerrar la sesión).
![1650402162048](https://user-images.githubusercontent.com/43360869/164104041-4dc55785-c66a-419e-96f7-ba651606867d.jpg)

### EmailSignInPage (AlertDialog que informa sobre un error en el campo email & password, respectivamente).
![1650402162069](https://user-images.githubusercontent.com/43360869/164104211-7287f380-781d-414f-9bfc-074e72a0eef9.jpg)

![1650402162058](https://user-images.githubusercontent.com/43360869/164104234-a875257c-22dd-4442-aa30-b5a5b8a975bd.jpg)

### Estado de carga al iniciar sesión con Google, Facebook o de forma Anónima (deshabilita los botones mientras se procesa la solicitud)
![1650906157228](https://user-images.githubusercontent.com/43360869/165138055-910cdf4b-6741-4ff7-b0fc-1a446b434a5d.jpg)

### Alert Dialog informando sobre un error de conexión
![1650906157213](https://user-images.githubusercontent.com/43360869/165138193-06232b71-6bbc-44b5-afcb-f03d0fce4c89.jpg)


